### PR TITLE
Add subscription page and improve plan details and FAQ

### DIFF
--- a/TrendFind/main.py
+++ b/TrendFind/main.py
@@ -794,6 +794,10 @@ def faq():
 def plan_details():
     return render_template("plan-details.html")
 
+@app.route("/subscription")
+def subscription():
+    return render_template("subscription.html")
+
 # Quick admin endpoint to (re)create DB
 @app.route("/initdb")
 def _initdb():

--- a/TrendFind/static/styles.css
+++ b/TrendFind/static/styles.css
@@ -589,9 +589,15 @@ body.dark-mode .futuristic-box p {
 .footer {
     background-color: rgba(0, 0, 0, 0.8);
     color: #fff;
-    padding: 20px 0;
+    padding: 10px 0;
     text-align: center;
     margin-top: auto;
+}
+
+.footer-logo {
+    width: 120px;
+    height: auto;
+    margin-bottom: 8px;
 }
 
 .footer p {

--- a/TrendFind/templates/faq.html
+++ b/TrendFind/templates/faq.html
@@ -301,9 +301,7 @@
 <div class="faq-item" data-category="plans">
     <button class="faq-question">Which payment methods do you accept?</button>
     <div class="faq-answer"><div class="faq-answer-inner">
-        <p>We accept all major credit and debit cards (Visa, Mastercard, AmEx),
-           Apple Pay, Google Pay and PayPal. Enterprise invoices can be paid by
-           bank transfer.</p>
+        <p>We accept all major credit and debit cards (Visa, Mastercard and American Express) along with PayPal. Apple Pay and Google Pay are supported through our Stripe checkout. Enterprise invoices can also be settled by bank transfer.</p>
     </div></div>
 </div>
 
@@ -351,6 +349,13 @@
 
 <!-- ─────────── DATA & ACCURACY  (4) ─────────── -->
 <div class="faq-item" data-category="data">
+    <button class="faq-question">How does TrendFind gather product data?</button>
+    <div class="faq-answer"><div class="faq-answer-inner">
+        <p>TrendFind aggregates publicly available information from major ecommerce marketplaces and social platforms. Our algorithms monitor sales velocity, pricing changes and consumer interest without scraping private data.</p>
+    </div></div>
+</div>
+
+<div class="faq-item" data-category="data">
     <button class="faq-question">How often are marketplace prices updated?</button>
     <div class="faq-answer"><div class="faq-answer-inner">
         <p>Amazon and Walmart prices refresh every 15 minutes. eBay auction data
@@ -361,9 +366,7 @@
 <div class="faq-item" data-category="data">
     <button class="faq-question">Where does your social-media data come from?</button>
     <div class="faq-answer"><div class="faq-answer-inner">
-        <p>We ingest public posts from TikTok, Instagram, Reddit and Pinterest
-           through official developer APIs, then run sentiment analysis to gauge
-           buzz and buyer intent.</p>
+        <p>We ingest public posts from TikTok, Instagram, Reddit and Pinterest through official developer APIs, then run sentiment analysis to gauge buzz and buyer intent.</p>
     </div></div>
 </div>
 

--- a/TrendFind/templates/plan-details.html
+++ b/TrendFind/templates/plan-details.html
@@ -395,8 +395,10 @@
         }
 
         .btn-plan {
-            width: 100%;
-            padding: 15px;
+            display: block;
+            width: auto;
+            padding: 15px 25px;
+            margin: 20px auto 0;
             border-radius: 10px;
             font-weight: 700;
             text-transform: uppercase;
@@ -957,13 +959,6 @@
             </div>
         </div>
     </section>
-
-<!-- In plan-details.html, update the buttons like this: -->
-<button class="btn-plan btn-outline-plan" onclick="location.href='/start-trial?plan=standard'">Start 7-Day Free Trial</button>
-
-<button class="btn-plan btn-primary-plan" onclick="location.href='/start-trial?plan=pro'">Start 7-Day Free Trial</button>
-
-<button class="btn-plan btn-outline-plan" onclick="location.href='/start-trial?plan=enterprise'">Start 7-Day Free Trial</button>
 
     <!-- Feature Comparison -->
     <section class="feature-comparison">

--- a/TrendFind/templates/subscription.html
+++ b/TrendFind/templates/subscription.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block title %}Subscribe - TrendFind{% endblock %}
+{% block content %}
+<section class="subscription-section" style="padding:100px 20px;text-align:center;">
+    <h1>Subscribe to TrendFind</h1>
+    <p>Choose a plan and start your 7-day free trial.</p>
+    <a href="{{ url_for('plan_details') }}" class="btn btn-primary">View Plans</a>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add dedicated subscription route and page with link to plan details.
- Update plan details layout: non-stretched trial buttons and working FAQ accordion.
- Refresh FAQ content and shrink footer with larger logo for better branding.

## Testing
- `python -m py_compile TrendFind/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897740b0bac8333b78d9b61ee05a014